### PR TITLE
fix(M2): Lint 技術負債解消 (#21)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'coverage', 'playwright-report', 'test-results'] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/src/components/BenchmarkPanel.tsx
+++ b/src/components/BenchmarkPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useLayerStore } from '../store/layerStore'
 import { generatePerfShapes, generatePerfLayers } from '../utils/perfHarness'
 
@@ -10,20 +10,23 @@ export function BenchmarkPanel() {
   const loadDocument = useLayerStore((s) => s.loadDocument)
   const shapeCount = useLayerStore((s) => s.shapes.length)
 
-  const runLoad = (count: number) => {
-    const layers = generatePerfLayers()
-    const start = performance.now()
-    const shapes = generatePerfShapes({
-      count,
-      layerId: layers[0].id,
-      area: { width: 5000, height: 5000 },
-      seed: 42,
-    })
-    loadDocument(layers, shapes)
-    const ms = performance.now() - start
-    setLastLoad({ count, ms })
-    console.log(`[Benchmark] Generated ${count} shapes in ${ms.toFixed(1)}ms`)
-  }
+  const runLoad = useCallback(
+    (count: number) => {
+      const layers = generatePerfLayers()
+      const start = performance.now()
+      const shapes = generatePerfShapes({
+        count,
+        layerId: layers[0].id,
+        area: { width: 5000, height: 5000 },
+        seed: 42,
+      })
+      loadDocument(layers, shapes)
+      const ms = performance.now() - start
+      setLastLoad({ count, ms })
+      console.log(`[Benchmark] Generated ${count} shapes in ${ms.toFixed(1)}ms`)
+    },
+    [loadDocument],
+  )
 
   if (!open) {
     return (

--- a/src/components/FPSMeter.tsx
+++ b/src/components/FPSMeter.tsx
@@ -6,10 +6,11 @@ export function FPSMeter() {
   const [fps, setFps] = useState(0)
   const [minFps, setMinFps] = useState(0)
   const samples = useRef<number[]>([])
-  const last = useRef(performance.now())
+  const last = useRef<number>(0)
   const raf = useRef<number>(0)
 
   useEffect(() => {
+    last.current = performance.now()
     const tick = () => {
       const now = performance.now()
       const delta = now - last.current

--- a/src/hooks/useTool.ts
+++ b/src/hooks/useTool.ts
@@ -265,7 +265,7 @@ export function useTool(stageToWorld: (x: number, y: number) => Point) {
   }, [activeTool, setSelectionBox, setDragOrigin])
 
   const handleDoubleClick = useCallback(
-    (_e: KonvaEventObject<MouseEvent>) => {
+    () => {
       if (activeTool === 'polyline' && isDrawing && drawPoints.length >= 4) {
         const shape: Shape = {
           id: nanoid(), type: 'polyline', layerId: activeLayerId, locked: false,

--- a/src/utils/perfHarness.test.ts
+++ b/src/utils/perfHarness.test.ts
@@ -60,6 +60,7 @@ describe('runMicroBenchmark', () => {
     const result = await runMicroBenchmark(() => {
       let x = 0
       for (let i = 0; i < 10; i++) x += i
+      return x
     }, 20)
     expect(result.count).toBe(20)
     expect(result.elapsedMs).toBeGreaterThanOrEqual(0)


### PR DESCRIPTION
## Summary

Issue #21 の lint 技術負債（5 errors + 3 warnings）を解消。

### 変更点
- **FPSMeter.tsx**: `useRef(performance.now())` を `useRef(0)` + `useEffect` 内初期化へ
  - 毎 render で `performance.now()` が評価される Rules of React 違反を解消
- **BenchmarkPanel.tsx**: `runLoad` を `useCallback` でラップし handler 明示化
- **useTool.ts**: `handleDoubleClick` の未使用引数 `_e` を削除（Konva 側が引数を渡しても未受領で問題なし）
- **perfHarness.test.ts**: マイクロベンチマーク ループ本体の `x` を return 値に変更
- **eslint.config.js**: `coverage` / `playwright-report` / `test-results` を ignore 追加
  - 自動生成ファイル由来の Unused eslint-disable 警告を抑止

### テスト結果
- `npm run lint`: ✅ 0 errors 0 warnings
- `npm run build`: ✅ 初期バンドル 489KB 維持（PERF-002 相当）
- tsc strict: エラーゼロ

### 影響範囲
- 機能変更なし（lint 指摘の純粋な機械的修正のみ）
- `handleDoubleClick` のシグネチャ変更は `onDblClick={handleDoubleClick}` 経由の利用のみで引数受領不要のため副作用なし

### 残課題
なし。Issue #21 は本 PR merge で Close。

Refs: #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ESLint設定を更新し、追加の出力・テストディレクトリを除外対象に追加

* **Refactor**
  * パフォーマンス計測コンポーネントの初期化タイミングを最適化
  * ベンチマーク機能の再計算ロジックを改善
  * ツール関連のイベントハンドラーをシンプル化

* **Tests**
  * マイクロベンチマークテストを更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->