### PR TITLE
test(M3): E2E-001 — Playwright 11 シナリオ達成

### DIFF
--- a/e2e/interaction.spec.ts
+++ b/e2e/interaction.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+
+// E2E-001: M3 additional scenarios — undo/redo, layer visibility, select+delete
+
+test.describe('CivilDraw — interaction scenarios', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('dialog', (d) => d.dismiss().catch(() => {}))
+    await page.goto('/')
+  })
+
+  test('undo removes a drawn shape, redo restores it', async ({ page }) => {
+    await page.getByTitle('線分').click()
+    const canvas = page.locator('canvas').first()
+    const box = await canvas.boundingBox()
+    expect(box).not.toBeNull()
+    if (!box) return
+
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await page.mouse.click(cx - 100, cy)
+    await page.mouse.click(cx + 100, cy)
+    await expect(page.getByText(/図形:\s*[1-9]/)).toBeVisible()
+
+    await page.getByTitle('元に戻す (Ctrl+Z)').click()
+    await expect(page.getByText(/図形:\s*0\b/)).toBeVisible()
+
+    await page.getByTitle('やり直し (Ctrl+Y)').click()
+    await expect(page.getByText(/図形:\s*[1-9]/)).toBeVisible()
+  })
+
+  test('layer visibility toggle hides and restores a layer', async ({ page }) => {
+    const hideBtn = page.getByTitle('非表示にする').first()
+    await expect(hideBtn).toBeVisible()
+
+    await hideBtn.click()
+    await expect(page.getByTitle('表示する').first()).toBeVisible()
+
+    await page.getByTitle('表示する').first().click()
+    await expect(page.getByTitle('非表示にする').first()).toBeVisible()
+  })
+
+  test('select tool selects a shape and delete button removes it', async ({ page }) => {
+    await page.getByTitle('線分').click()
+    const canvas = page.locator('canvas').first()
+    const box = await canvas.boundingBox()
+    expect(box).not.toBeNull()
+    if (!box) return
+
+    const cx = box.x + box.width / 2
+    const cy = box.y + box.height / 2
+    await page.mouse.click(cx - 50, cy)
+    await page.mouse.click(cx + 50, cy)
+    await expect(page.getByText(/図形:\s*[1-9]/)).toBeVisible()
+
+    await page.getByTitle('選択').click()
+    await page.mouse.click(cx, cy)
+    // Delete button appears only when shapes are selected
+    await expect(page.getByTitle('削除 (Delete)')).toBeVisible({ timeout: 3000 })
+    await page.getByTitle('削除 (Delete)').click()
+    await expect(page.getByText(/図形:\s*0\b/)).toBeVisible()
+  })
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
 const perfPort = 5190
-const port = process.env.PERF_RUN ? perfPort : 5173
+const devPort = process.env.DEV_PORT ? parseInt(process.env.DEV_PORT) : 5173
+const port = process.env.PERF_RUN ? perfPort : devPort
 const baseURL = `http://localhost:${port}`
 
 export default defineConfig({
@@ -24,7 +25,8 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
-  projects: process.env.PERF_RUN
+  // USE_FIREFOX=1 allows local runs on Linux where Chromium headless-shell crashes (SIGTRAP on kernel 6.17+)
+  projects: process.env.PERF_RUN || process.env.USE_FIREFOX
     ? [{ name: 'firefox', use: { ...devices['Desktop Firefox'] } }]
     : [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
 })


### PR DESCRIPTION
## 変更内容

M3 完了条件「E2E 10 シナリオ以上通過」を満たすため、3 シナリオを追加しました。

### 追加テスト (`e2e/interaction.spec.ts`)

| # | シナリオ | 検証内容 |
|---|----------|----------|
| 9 | Undo/Redo | 線分追加 → undo で消去 → redo で復元 |
| 10 | レイヤー可視化トグル | 👁ボタンで非表示 → 表示に戻す |
| 11 | 選択 → 削除 | 図形クリック選択 → 削除ボタンで除去 |

### playwright.config.ts 改善

- `DEV_PORT` 環境変数: ローカルで別サービスが 5173 を占有する場合に代替ポート指定
- `USE_FIREFOX=1`: Linux kernel 6.17+ の Chromium SIGTRAP 問題を回避

## テスト結果

```
11/11 passed (Firefox headless, 7.2s)
```

## 影響範囲

- CI 挙動: 変わらず (Chromium / testIgnore は維持)
- `DEV_PORT` / `USE_FIREFOX` は CI 未設定のためデフォルト動作に影響なし

## 残課題

- SYM-001 (#25) シンボル 8→30 種 — 次フェーズ
- HATCH-001 (#26) ハッチング 4→10 種 — 次フェーズ
- UX-001 図形回転・ミラー — M3 後半

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 新しいエンドツーエンドテストスイートを追加しました。元に戻す/やり直す、レイヤー表示切り替え、選択と削除の機能をカバーしています。

* **Chores**
  * 開発サーバーポート設定を改善し、ブラウザテスト環境の柔軟性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->