### PR TITLE
[M3/UX-002] 複数選択時の一括プロパティ変更 — BulkPanel + bulkUpdateShapes

### DIFF
--- a/src/components/PropertyPanel/PropertyPanel.tsx
+++ b/src/components/PropertyPanel/PropertyPanel.tsx
@@ -1,8 +1,9 @@
 import { useLayerStore } from '../../store/layerStore'
 import type { Shape } from '../../types/geometry'
+import type { Layer } from '../../types/layer'
 
 export function PropertyPanel() {
-  const { shapes, selectedIds, updateShape, removeShapes } = useLayerStore()
+  const { shapes, layers, selectedIds, updateShape, removeShapes, bulkUpdateShapes } = useLayerStore()
   const selected = shapes.filter((s) => selectedIds.includes(s.id))
 
   if (selected.length === 0) {
@@ -15,15 +16,13 @@ export function PropertyPanel() {
 
   if (selected.length > 1) {
     return (
-      <div className="p-2 text-xs text-gray-200 bg-gray-800">
-        <p className="mb-2">{selected.length} 件選択中</p>
-        <button
-          onClick={() => removeShapes(selectedIds)}
-          className="px-2 py-1 bg-red-700 hover:bg-red-600 rounded text-xs"
-        >
-          削除
-        </button>
-      </div>
+      <BulkPanel
+        count={selected.length}
+        shapes={selected}
+        layers={layers}
+        onBulkUpdate={(patch) => bulkUpdateShapes(selectedIds, patch)}
+        onDelete={() => removeShapes(selectedIds)}
+      />
     )
   }
 
@@ -37,6 +36,56 @@ export function PropertyPanel() {
         className="mt-2 px-2 py-1 bg-red-700 hover:bg-red-600 rounded text-xs w-full"
       >
         削除
+      </button>
+    </div>
+  )
+}
+
+interface BulkPanelProps {
+  count: number
+  shapes: Shape[]
+  layers: Layer[]
+  onBulkUpdate: (patch: { layerId?: string; locked?: boolean }) => void
+  onDelete: () => void
+}
+
+function BulkPanel({ count, shapes, layers, onBulkUpdate, onDelete }: BulkPanelProps) {
+  const commonLayerId = shapes.every((s) => s.layerId === shapes[0].layerId) ? shapes[0].layerId : ''
+  const allLocked = shapes.every((s) => s.locked)
+
+  return (
+    <div className="p-2 text-xs text-gray-200 bg-gray-800 space-y-2">
+      <p className="font-semibold">{count} 件選択中</p>
+
+      <label className="block">
+        <span className="text-gray-400">レイヤー移動</span>
+        <select
+          value={commonLayerId}
+          onChange={(e) => e.target.value && onBulkUpdate({ layerId: e.target.value })}
+          className="mt-0.5 w-full bg-gray-700 border border-gray-600 rounded px-1"
+        >
+          {commonLayerId === '' && <option value="">—複数レイヤー—</option>}
+          {layers.map((l) => (
+            <option key={l.id} value={l.id}>{l.name}</option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={allLocked}
+          onChange={(e) => onBulkUpdate({ locked: e.target.checked })}
+          className="w-3 h-3"
+        />
+        <span>ロック</span>
+      </label>
+
+      <button
+        onClick={onDelete}
+        className="w-full px-2 py-1 bg-red-700 hover:bg-red-600 rounded text-xs"
+      >
+        削除 ({count})
       </button>
     </div>
   )

--- a/src/store/layerStore.test.ts
+++ b/src/store/layerStore.test.ts
@@ -193,3 +193,46 @@ describe('layerStore — document load/clear', () => {
     expect(state.shapes).toHaveLength(0)
   })
 })
+
+describe('layerStore — bulkUpdateShapes', () => {
+  it('moves multiple shapes to a new layer', () => {
+    const { addShape, addLayer, bulkUpdateShapes, activeLayerId, layers } = useLayerStore.getState()
+    addShape(makeLine('s1', activeLayerId))
+    addShape(makeRect('s2', activeLayerId))
+    const newLayerId = useLayerStore.getState().layers[1].id
+    bulkUpdateShapes(['s1', 's2'], { layerId: newLayerId })
+    const { shapes } = useLayerStore.getState()
+    expect(shapes.every((s) => s.layerId === newLayerId)).toBe(true)
+    void layers; void addLayer
+  })
+
+  it('locks multiple shapes at once', () => {
+    const { addShape, bulkUpdateShapes, activeLayerId } = useLayerStore.getState()
+    addShape(makeLine('s1', activeLayerId))
+    addShape(makeRect('s2', activeLayerId))
+    bulkUpdateShapes(['s1', 's2'], { locked: true })
+    const { shapes } = useLayerStore.getState()
+    expect(shapes.every((s) => s.locked)).toBe(true)
+  })
+
+  it('only affects specified ids', () => {
+    const { addShape, bulkUpdateShapes, activeLayerId } = useLayerStore.getState()
+    addShape(makeLine('s1', activeLayerId))
+    addShape(makeRect('s2', activeLayerId))
+    const newLayerId = useLayerStore.getState().layers[1].id
+    bulkUpdateShapes(['s1'], { layerId: newLayerId })
+    const { shapes } = useLayerStore.getState()
+    expect(shapes.find((s) => s.id === 's1')?.layerId).toBe(newLayerId)
+    expect(shapes.find((s) => s.id === 's2')?.layerId).toBe(activeLayerId)
+  })
+
+  it('pushes to history for undo support', () => {
+    const { addShape, bulkUpdateShapes, activeLayerId } = useLayerStore.getState()
+    addShape(makeLine('s1', activeLayerId))
+    const { historyIndex: before } = useLayerStore.getState()
+    const newLayerId = useLayerStore.getState().layers[1].id
+    bulkUpdateShapes(['s1'], { layerId: newLayerId })
+    const { historyIndex: after } = useLayerStore.getState()
+    expect(after).toBe(before + 1)
+  })
+})

--- a/src/store/layerStore.ts
+++ b/src/store/layerStore.ts
@@ -36,6 +36,7 @@ interface LayerState {
   pasteClipboard: (dx?: number, dy?: number) => void
   duplicateSelection: () => void
   transformSelectedShapes: (op: TransformOp) => void
+  bulkUpdateShapes: (ids: string[], patch: { layerId?: string; locked?: boolean }) => void
 
   undo: () => void
   redo: () => void
@@ -233,6 +234,14 @@ export const useLayerStore = create<LayerState>()((set, get) => {
         selectedIds: dups.map((s) => s.id),
         ...h,
       })
+    },
+
+    bulkUpdateShapes: (ids, patch) => {
+      const shapes = get().shapes.map((s) =>
+        ids.includes(s.id) ? ({ ...s, ...patch } as Shape) : s,
+      )
+      const h = pushHistory(get().history, get().historyIndex, shapes)
+      set({ shapes, ...h })
     },
 
     transformSelectedShapes: (op) => {


### PR DESCRIPTION
## 変更内容

UX-002 (#31): 複数図形選択時にレイヤー移動・ロック切替を一括変更できる機能。

### 追加機能

**PropertyPanel — 複数選択時の BulkPanel**

| 操作 | 内容 |
|---|---|
| レイヤー移動 | 全選択図形を対象レイヤーへ一括移動。共通レイヤー外は「—複数レイヤー—」プレースホルダ表示 |
| ロック | 全選択図形のロック状態を一括切替 |
| 削除 | 件数付きで一括削除 |

### 実装ファイル

- `src/store/layerStore.ts` — `bulkUpdateShapes(ids, patch)` アクション追加 (Undo/Redo 対応)
- `src/components/PropertyPanel/PropertyPanel.tsx` — `BulkPanel` コンポーネント追加
- `src/store/layerStore.test.ts` — 4 テストケース追加

## テスト結果

- `tsc --noEmit`: ✅ エラーなし
- `vite build`: ✅ 成功
- `eslint`: ✅ エラーなし

## 影響範囲

`PropertyPanel` の複数選択時表示のみ変更。既存の単一選択・描画機能への影響なし。