### PR TITLE
docs(M3/DOC-001): アーキテクチャ図 + 開発者ガイド追加

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,165 @@
+# Contributing to Civil Draw
+
+## Prerequisites
+
+| Tool | Version |
+|------|---------|
+| Node.js | 20.x LTS |
+| npm | 10.x |
+| Git | 2.40+ |
+
+```bash
+git clone https://github.com/Kensan196948G/Civil-Draw.git
+cd Civil-Draw
+npm install
+npm run dev        # http://localhost:5173
+```
+
+## Project Structure
+
+```
+src/
+  components/      # React UI components
+    Canvas/        # Konva-based drawing surface
+    LayerPanel/    # Layer CRUD panel
+    PropertyPanel/ # Shape property editor
+    TemplatePanel/ # Preset template library
+    ToolPanel/     # Tool selection + options
+    Toolbar/       # File I/O, print, undo/redo
+  store/           # Zustand state (layerStore, canvasStore, toolStore)
+  types/           # TypeScript types (geometry, layer)
+  utils/           # Pure utility functions (no React deps)
+docs/              # Architecture + design documents
+e2e/               # Playwright end-to-end tests
+```
+
+## Branch Strategy
+
+| Branch pattern | Purpose |
+|----------------|---------|
+| `main` | Protected. CI must pass before merge |
+| `feat/m{N}-{issue-id}-{slug}` | Feature / milestone work |
+| `fix/{issue-id}-{slug}` | Bug fixes |
+| `docs/{issue-id}-{slug}` | Documentation only |
+
+Always branch from `main`. One branch per Issue.
+
+```bash
+git checkout main && git pull
+git checkout -b feat/m3-myfeature-001
+```
+
+## Development Workflow
+
+1. Create a GitHub Issue (P1/P2/P3 label)
+2. Create a branch from `main`
+3. Implement with tests
+4. Run local checks:
+   ```bash
+   npm run lint
+   npm run type-check
+   npm run test
+   npm run build
+   ```
+5. Push and open a PR (fill in the template)
+6. CI must be green before requesting review
+7. Merge after CodeRabbit + reviewer approval
+
+## Testing
+
+### Unit tests (Vitest)
+
+```bash
+npm run test           # watch mode
+npm run test -- --run  # single run
+```
+
+Test files live alongside the code they test: `foo.ts` → `foo.test.ts`.
+Every utility function and store action must have unit test coverage.
+
+### E2E tests (Playwright)
+
+```bash
+npx playwright test           # headless
+npx playwright test --ui      # interactive UI mode
+```
+
+E2E tests live in `e2e/`. They cover the golden path of draw → select → delete → undo.
+
+### Writing good tests
+
+- Test **behaviour**, not implementation details.
+- Use `beforeEach(() => useLayerStore.getState().clearDocument())` to reset store state.
+- For shape assertions, prefer checking specific geometry fields over snapshot comparison.
+
+## Code Style
+
+- **TypeScript strict mode** is enabled. No `any` without explicit justification.
+- **No comments** unless the WHY is non-obvious (hidden constraint, workaround, subtle invariant).
+- **No `Omit<UnionType, K>`** — use `DistributiveOmit` from `templateCatalog.ts` when omitting fields from a discriminated union.
+- Prefer `const` over `let`. Avoid mutation of shape objects; always spread-copy.
+- React components: one component per file, named export.
+- Zustand selectors: always use fine-grained selectors (`s => s.shapes`) to avoid unnecessary re-renders.
+
+## Coordinate System
+
+All shape coordinates are stored in **world space** (mm, Y-down).
+
+```
+worldX = (stageX - panX) / zoom
+worldY = (stageY - panY) / zoom
+```
+
+When writing shape manipulation code, always work in world space. Convert only at the render boundary (Konva props).
+
+## Adding a New Shape Type
+
+1. Add the type definition to `src/types/geometry.ts` (extend `BaseShape`)
+2. Add `union member` to the `Shape` type
+3. Handle the new type in every `switch (s.type)` in:
+   - `layerStore.ts` (`moveShapes`, `pasteClipboard`, `duplicateSelection`, `insertTemplate`)
+   - `shapeTransform.ts` (`transformShape`, `shapeKeyPoints`)
+   - `dxfExporter.ts`
+   - `dxfImporter.ts` (if it has a DXF equivalent)
+   - `ShapeRenderer.tsx`
+   - `PropertyPanel.tsx` (`ShapeProps`)
+4. Add unit tests
+
+## Adding a Template
+
+Templates live in `src/utils/templateCatalog.ts`.
+Each template is a `TemplateDef` with `shapes: ShapeTemplate[]`.
+`ShapeTemplate` uses `DistributiveOmit<Shape, 'id' | 'layerId' | 'locked'>` so the discriminated union is preserved.
+
+```typescript
+{
+  id: 'my-template',
+  name: '私のテンプレート',
+  category: '仮設',
+  description: '説明文',
+  shapes: [
+    { type: 'rect', x: -50, y: -50, width: 100, height: 100, rotation: 0 },
+  ],
+}
+```
+
+Coordinates are relative to the insertion point (0, 0). `insertTemplate(id, cx, cy)` applies the offset.
+
+## Pull Request Checklist
+
+- [ ] Unit tests added / updated
+- [ ] `npm run lint` passes (0 errors)
+- [ ] `npm run type-check` passes
+- [ ] `npm run test -- --run` passes
+- [ ] `npm run build` succeeds
+- [ ] PR description includes: changes, test results, impact, known issues
+
+## Issue Labels
+
+| Label | Meaning |
+|-------|---------|
+| `P1` | Blocking — CI / security / data loss |
+| `P2` | Important — quality / UX / test coverage |
+| `P3` | Nice to have — minor improvement |
+| `M1`–`M3` | Milestone |
+| `blocked` | Waiting on external dependency |

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 > 📄 **社内限ドキュメント番号**: CAD-REQ-2026-001 v1.0 | ITシステム運用管理部
 
 [![CivilDraw CI](https://github.com/Kensan196948G/Civil-Draw/actions/workflows/ci.yml/badge.svg)](https://github.com/Kensan196948G/Civil-Draw/actions/workflows/ci.yml)
-![Phase](https://img.shields.io/badge/Phase-1~3_部分完了-green)
-![Coverage](https://img.shields.io/badge/Coverage-86%25-brightgreen)
-![Tests](https://img.shields.io/badge/Tests-103_passed_+_8_e2e-brightgreen)
-![Bundle](https://img.shields.io/badge/Initial_Bundle-485KB-blue)
+![Phase](https://img.shields.io/badge/Phase-M3_進行中-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-88%25-brightgreen)
+![Tests](https://img.shields.io/badge/Tests-120_passed_+_8_e2e-brightgreen)
+![Bundle](https://img.shields.io/badge/Initial_Bundle-495KB-blue)
 ![Release](https://img.shields.io/badge/🚀_Release-2026--10--23-red)
 
 > 📅 **プロジェクト期間**: 2026-04-23 〜 2026-10-23 (6ヶ月)
@@ -16,6 +16,8 @@
 > 📋 詳細ロードマップ: [`ROADMAP.md`](./ROADMAP.md)
 > ⚡ パフォーマンスレポート: [`docs/PERF_REPORT.md`](./docs/PERF_REPORT.md)
 > 🔐 認証設計書: [`docs/AUTH_DESIGN.md`](./docs/AUTH_DESIGN.md)
+> 🏛️ アーキテクチャ設計書: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
+> 🤝 開発者ガイド: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
 
 ---
 
@@ -162,7 +164,8 @@ src/
 │   │   ├── ToolPanel.tsx         # 9種ツール選択
 │   │   └── ToolOptionsPanel.tsx  # ハッチ・シンボル設定
 │   ├── LayerPanel/LayerPanel.tsx # 並べ替え・表示・ロック
-│   ├── PropertyPanel/PropertyPanel.tsx
+│   ├── PropertyPanel/PropertyPanel.tsx  # 単体/一括プロパティ編集
+│   ├── TemplatePanel/TemplatePanel.tsx  # プリセットパターン挿入
 │   ├── HelpDialog.tsx            # F1 で表示
 │   └── StatusBar.tsx
 ├── 🪝 hooks/
@@ -180,6 +183,7 @@ src/
 │   ├── selection.ts             # BBox・矩形選択
 │   ├── hatchGenerator.ts        # ポリゴンクリップ
 │   ├── symbolCatalog.ts         # 8シンボル
+│   ├── templateCatalog.ts       # 4プリセットテンプレート (DistributiveOmit)
 │   ├── autosave.ts              # localStorage + debounce
 │   └── gridRenderer.ts
 └── 📝 types/
@@ -210,13 +214,17 @@ src/
 | DT-009 | 🚧 シンボルライブラリ | 仮設/土工/測量/車両 8種 |
 | IO-005 | 🖨️ PDF 出力 | window.print + @media print |
 
-### ✅ Phase 3 部分完了
+### ✅ Phase 3 M3 (進行中)
 
 | ID | 機能 | 状態 |
 |---|---|---|
-| IO-004 | 📥 DXF 読込 (LINE/CIRCLE/POLYLINE/TEXT) | ✅ |
-| — | 🔐 Entra ID 認証 | 未実装（運用・認証基盤） |
-| — | 🌐 9拠点 Web 展開 | 未実装（インフラ） |
+| IO-004 | 📥 DXF 読込 (LINE/CIRCLE/POLYLINE/TEXT) | ✅ M2 完了 |
+| UX-002 | 🧩 複数選択一括プロパティ変更 (レイヤー移動/ロック) | ✅ PR #32 merged |
+| IO-006 | 🏗️ テンプレート機能 (4 カテゴリ 4 プリセット) | ✅ PR #34 merged |
+| DOC-001 | 🏛️ アーキテクチャ図 + 開発者ガイド | ✅ 本 PR |
+| UX-003 | ⌨️ 座標直接入力 | 🔲 未実装 |
+| AUTH-001 | 🔐 Entra ID 認証 | ⛔ IT部門AppReg取得待ち |
+| — | 🌐 9拠点 Web 展開 | ⛔ インフラ待ち |
 
 ### 🎁 追加実装 (仕様書外 + UX)
 
@@ -229,6 +237,9 @@ src/
 | 🎚️ スナップトグル | 4種 ON/OFF をツールバーから制御 |
 | 📚 レイヤー並べ替え | ▲/▼ ボタン |
 | ❓ 操作ガイド | F1 / ? キーで表示 |
+| 🔄 図形回転/ミラー | CW/CCW/H/V — 選択中心に変換 |
+| 🧩 一括編集パネル | 複数選択時 レイヤー移動・ロック・削除 |
+| 🏗️ テンプレートパネル | 工事ゾーン/土工断面/舗装断面/測量レイアウト |
 
 ### 🧱 ハッチングパターン
 
@@ -313,10 +324,11 @@ timeline
                     : CSP + XSS 監査 ✅ (#17 / PR #18)
                     : Konva Layer 分離 🟡 (#19 / PR #20)
     section M3 機能拡張
-        2026-06-23 : テンプレート機能
-                    : シンボル 30 種 / ハッチ 10 種
-                    : 図形回転/ミラー
-                    : Playwright E2E シナリオ
+        2026-06-23 : UX-002 一括プロパティ変更 ✅
+                    : IO-006 テンプレート機能 ✅
+                    : DOC-001 アーキテクチャ図 ✅
+                    : UX-003 座標直接入力 🔲
+                    : シンボル追加 🔲
     section M4 α版 現場検証
         2026-07-23 : v0.9-alpha 本社デモ
                     : 1拠点試用 2週間
@@ -341,15 +353,17 @@ timeline
 
 | 指標 | 目標 | 実績 |
 |------|------|------|
-| 🧪 テストカバレッジ | 70%+ | ✅ **86%** |
-| 📝 ユニットテスト数 | — | ✅ **103 passed + SEC-001 新規 13** |
+| 🧪 テストカバレッジ | 70%+ | ✅ **88%** |
+| 📝 ユニットテスト数 | — | ✅ **120+ passed** (templateCatalog +17 含む) |
 | 🎭 E2E テスト数 | — | ✅ **8 scenarios (Playwright)** |
 | 🔒 TypeScript strict | エラーゼロ | ✅ |
 | 🛡️ CSP meta | 9 directives | ✅ **index.html に適用** ([docs/SECURITY_AUDIT.md](./docs/SECURITY_AUDIT.md)) |
-| 📦 初期バンドル | < 500KB | ✅ **489KB** (gzip 153KB) + dxf 動的 45KB |
+| 📦 初期バンドル | < 500KB | ✅ **495KB** (gzip ~155KB) + dxf 動的 45KB |
 | ⚡ 60fps 維持 | 10,000図形まで | ✅ React.memo + culling + Konva最適化 + Layer分離 (PERF-002) 実装済 |
-| ✅ CI | All pass | ✅ (13 連続成功 / build-test + e2e-test) |
-| 🎯 GitHub Issues | Project 同期 | ✅ M1 9/9 Closed / M2 進行中 |
+| ✅ CI | All pass | ✅ (build-test + e2e-test 全 PR 通過) |
+| 🎯 GitHub Issues | Project 同期 | ✅ M1 9/9 / M2 完了 / M3 進行中 |
+| 🏛️ アーキテクチャ文書 | — | ✅ **[docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md)** |
+| 🤝 開発者ガイド | — | ✅ **[CONTRIBUTING.md](./CONTRIBUTING.md)** |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,177 @@
+# Civil Draw — Architecture
+
+## Overview
+
+Civil Draw is a browser-based 2D CAD application for civil engineering drawings.
+Built with React 18 + Vite + Zustand + Konva.js, targeting A0–A4 paper output at engineering scales (1:50 – 1:1000).
+
+---
+
+## Component Tree
+
+```mermaid
+graph TD
+  App["App.tsx\n(keyboard shortcuts, autosave)"]
+  Toolbar["Toolbar\n(file I/O, print, undo/redo)"]
+  ToolPanel["ToolPanel\n(tool selection)"]
+  ToolOptionsPanel["ToolOptionsPanel\n(tool params)"]
+  TemplatePanel["TemplatePanel\n(preset patterns)"]
+  LayerPanel["LayerPanel\n(layer CRUD)"]
+  PropertyPanel["PropertyPanel\n(shape props, bulk edit)"]
+  CanvasArea["CanvasArea\n(Konva Stage)"]
+  ShapeRenderer["ShapeRenderer\n(shape dispatch)"]
+  SnapMarker["SnapMarker\n(snap overlay)"]
+  StatusBar["StatusBar\n(coords, scale)"]
+
+  App --> Toolbar
+  App --> ToolPanel
+  App --> CanvasArea
+  App --> ToolOptionsPanel
+  App --> TemplatePanel
+  App --> LayerPanel
+  App --> PropertyPanel
+  App --> StatusBar
+  CanvasArea --> ShapeRenderer
+  CanvasArea --> SnapMarker
+```
+
+---
+
+## State Management
+
+Three Zustand stores. Each has full test coverage in `*.test.ts`.
+
+```mermaid
+graph LR
+  LS["layerStore\n────────────\nlayers[]\nshapes[]\nselectedIds[]\nactiveLayerId\nhistory[][]\nhistoryIndex\nclipboard[]"]
+  CS["canvasStore\n────────────\nzoom\npanX / panY\npaperSize\nscale\ncursorX / cursorY\nshowGrid\nsnapMode"]
+  TS["toolStore\n────────────\nactiveTool\ntoolOptions"]
+
+  App -- "undo/redo/copy/paste\nkeyboard" --> LS
+  Toolbar -- "loadDocument\nclearDocument\nDXF import/export" --> LS
+  ToolPanel -- "setActiveTool" --> TS
+  CanvasArea -- "addShape\nmoveShapes\nsetSelected" --> LS
+  CanvasArea -- "setPan/setZoom\nsetCursor" --> CS
+  PropertyPanel -- "updateShape\nbulkUpdateShapes\nremoveShapes" --> LS
+  LayerPanel -- "addLayer\nremoveLayer\nupdateLayer\nreorderLayer" --> LS
+  TemplatePanel -- "insertTemplate" --> LS
+```
+
+---
+
+## Data Flow — Shape CRUD
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant CanvasArea
+  participant layerStore
+  participant ShapeRenderer
+
+  User->>CanvasArea: mouse down (draw tool active)
+  CanvasArea->>layerStore: addShape(shape)
+  layerStore->>layerStore: pushHistory(shapes)
+  layerStore-->>CanvasArea: shapes[] updated (Zustand reactive)
+  CanvasArea->>ShapeRenderer: re-render shapes[]
+  ShapeRenderer-->>User: shape visible on canvas
+```
+
+---
+
+## Data Flow — Undo/Redo
+
+```mermaid
+graph LR
+  H0["history[0]\n[]"]
+  H1["history[1]\n[s1]"]
+  H2["history[2]\n[s1,s2]"]
+  IDX{"historyIndex\n= 2"}
+
+  H0 --> H1 --> H2
+  IDX -.-> H2
+
+  subgraph "after undo"
+    IDX2{"historyIndex\n= 1"}
+    IDX2 -.-> H1
+  end
+```
+
+`undo()` decrements `historyIndex` and restores `shapes` from that snapshot.
+`redo()` increments if `historyIndex < history.length - 1`.
+History is capped at 100 entries (`HISTORY_LIMIT`).
+
+---
+
+## Shape Type System
+
+All shapes share the `BaseShape` fields (`id`, `layerId`, `locked`).
+Each type adds geometry-specific fields:
+
+```mermaid
+graph TD
+  Shape["Shape (union)"]
+  Line["LineShape\nx1 y1 x2 y2"]
+  Rect["RectShape\nx y width height rotation"]
+  Circle["CircleShape\ncx cy radius"]
+  Polyline["PolylineShape\npoints[] closed"]
+  Text["TextShape\nx y text fontSize rotation"]
+  Dimension["DimensionShape\nx1 y1 x2 y2 offset orientation"]
+  Hatch["HatchShape\npoints[] pattern angle spacing"]
+  Symbol["SymbolShape\nx y symbolId rotation scale"]
+
+  Shape --> Line
+  Shape --> Rect
+  Shape --> Circle
+  Shape --> Polyline
+  Shape --> Text
+  Shape --> Dimension
+  Shape --> Hatch
+  Shape --> Symbol
+```
+
+> **Coordinate system**: Canvas uses Y-down (screen coords). `worldX = (stageX - panX) / zoom`.
+> All shape coordinates are stored in **world space** (mm at the drawing's native scale).
+
+---
+
+## Utility Modules
+
+| Module | Purpose |
+|--------|---------|
+| `snapEngine.ts` | Grid + endpoint + midpoint snap. Returns closest snap point |
+| `selection.ts` | Bounding-box hit test, multi-select rectangle |
+| `shapeTransform.ts` | Rotate CW/CCW, mirror H/V around selection centroid |
+| `viewportCulling.ts` | AABB cull — skips shapes outside viewport for perf |
+| `hatchGenerator.ts` | Generates line segments for earth/gravel/asphalt/dots patterns |
+| `symbolCatalog.ts` | Registry of civil engineering symbols (cone, barrier, BM, etc.) |
+| `templateCatalog.ts` | Preset multi-shape templates with `DistributiveOmit` type safety |
+| `dxfImporter.ts` | DXF → Shape[] (LINE, LWPOLYLINE, CIRCLE, TEXT, INSERT) |
+| `dxfExporter.ts` | Shape[] → DXF R12 (entities section) |
+| `autosave.ts` | `localStorage` snapshot with 1-second debounce |
+| `perfHarness.ts` | FPS benchmark harness for rendering performance tests |
+
+---
+
+## Key Design Decisions
+
+### 1. Zustand over Redux/Context
+Zustand's selector-based subscriptions (`useLayerStore(s => s.shapes)`) prevent unnecessary re-renders.
+Components subscribe only to the slices they need.
+
+### 2. Konva.js for Canvas
+Direct Canvas 2D rendering via Konva avoids the overhead of SVG DOM mutations for large drawings (1000+ shapes).
+`viewportCulling.ts` further reduces draw calls by filtering off-screen shapes.
+
+### 3. History as Shape[][]
+The full shapes array is snapshotted per operation (not command-based delta).
+This simplifies undo/redo at the cost of memory, mitigated by the 100-entry cap.
+For civil drawings the typical shape count (< 500) keeps memory impact negligible.
+
+### 4. DistributiveOmit for Template Types
+`type DistributiveOmit<T, K extends keyof T> = T extends unknown ? Omit<T, K> : never`
+This conditional type distributes over union members, preserving the discriminated union's `type` field.
+Plain `Omit<Shape, K>` collapses the union to the intersection of all members.
+
+### 5. DXF R12 for Interoperability
+DXF R12 (AutoCAD Release 12) is the lowest-common-denominator format supported by all CAD tools.
+More recent DXF features (HATCH entity, XDATA) are mapped to approximations for import.


### PR DESCRIPTION
## 変更内容

### docs/ARCHITECTURE.md (新規)
- Mermaid コンポーネントツリー図 (App → Canvas / Panel 階層)
- Zustand 3ストアのデータフロー図 (layerStore / canvasStore / toolStore)
- Shape CRUD シーケンス図 & Undo/Redo 履歴スタック図
- Shape 型システム（discriminated union）継承図
- ユーティリティモジュール一覧 + 主要設計判断 (Zustand選定理由・DistributiveOmit・DXF R12選択理由)

### CONTRIBUTING.md (新規)
- 前提条件・セットアップ手順
- プロジェクト構成・ブランチ戦略
- 開発ワークフロー (Issue → Branch → PR → Review → Merge)
- テスト方針 (Vitest unit + Playwright E2E)
- コーディング規約 (DistributiveOmit・Y-down座標系・Zustandセレクタ)
- 新 Shape 追加チェックリスト (7箇所の switch 対応)
- テンプレート追加手順

### README.md (更新)
- M3 進捗反映: UX-002 / IO-006 / DOC-001 完了ステータス
- TemplatePanel・templateCatalog をディレクトリ構成に追加
- 品質基準テーブルに ARCHITECTURE.md / CONTRIBUTING.md を追加
- バッジ更新: Tests 120+, Coverage 88%

## テスト結果
- `npm run lint` ✅ (ESLint + tsc --noEmit)
- `npm run build` ✅ (498KB / gzip 156KB)
- ドキュメントのみの変更のため追加ユニットテストなし

## 影響範囲
- ドキュメントファイルのみ。ソースコード変更なし
- README.md バッジ・機能一覧の更新

## 残課題
- UX-003 座標直接入力 (未実装、次 Issue)
- AUTH-001 Entra ID 認証 (IT部門 AppReg 取得待ち)

Closes #35