### PR TITLE
[M4/P2] PERF-003: 印刷時の高DPI対応 (Konva pixelRatio:3 + 印刷プレビューウィンドウ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm run dev
 | `npm run preview` | 👀 ビルド成果物プレビュー |
 | `npm run test` | ✅ 全ユニットテスト実行 (103 tests) |
 | `npm run test:coverage` | 📊 カバレッジ付きテスト |
-| `npm run test:e2e` | 🎭 Playwright E2E テスト (8 scenarios) |
+| `npm run test:e2e` | 🎭 Playwright E2E テスト (23 scenarios) |
 | `npm run test:e2e:ui` | 🖱️ Playwright UI モード |
 | `npm run lint` | 🔍 ESLint + 型チェック |
 
@@ -367,7 +367,7 @@ timeline
 |------|------|------|
 | 🧪 テストカバレッジ | 70%+ | ✅ **88%** |
 | 📝 ユニットテスト数 | — | ✅ **120+ passed** (templateCatalog +17 含む) |
-| 🎭 E2E テスト数 | — | ✅ **8 scenarios (Playwright)** |
+| 🎭 E2E テスト数 | — | ✅ **23 scenarios (Playwright)** |
 | 🔒 TypeScript strict | エラーゼロ | ✅ |
 | 🛡️ CSP meta | 9 directives | ✅ **index.html に適用** ([docs/SECURITY_AUDIT.md](./docs/SECURITY_AUDIT.md)) |
 | 📦 初期バンドル | < 500KB | ✅ **495KB** (gzip ~155KB) + dxf 動的 45KB |

--- a/e2e/print-hires.spec.ts
+++ b/e2e/print-hires.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from '@playwright/test'
+
+// PERF-003: high-DPI print — PDF export opens a new window with canvas image
+
+test.describe('CivilDraw — PERF-003 high-DPI print', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('dialog', (d) => d.dismiss().catch(() => {}))
+    await page.goto('/')
+  })
+
+  test('PDF出力 button opens a new page with canvas image', async ({ page, context }) => {
+    // Draw a line so the canvas has content
+    await page.getByTitle('線分').click()
+    const canvas = page.locator('canvas').first()
+    const box = await canvas.boundingBox()
+    expect(box).not.toBeNull()
+    if (!box) return
+    await page.mouse.click(box.x + 200, box.y + 200)
+    await page.mouse.click(box.x + 400, box.y + 400)
+
+    // Click PDF button — expect a new page/popup to open
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      page.getByRole('button', { name: /PDF出力/ }).click(),
+    ])
+
+    await popup.waitForLoadState('domcontentloaded')
+
+    // The popup should contain an <img> with a data URL
+    const img = popup.locator('img').first()
+    await expect(img).toBeVisible({ timeout: 5000 })
+    const imgSrc = await img.getAttribute('src')
+    expect(imgSrc).toMatch(/^data:image\//)
+
+    // Should also have print/close buttons
+    await expect(popup.getByRole('button', { name: '印刷' })).toBeVisible()
+    await expect(popup.getByRole('button', { name: '閉じる' })).toBeVisible()
+  })
+
+  test('PDF出力 does not crash main page', async ({ page, context }) => {
+    // Even if popup is blocked, main page must remain functional
+    context.on('page', (popup) => popup.close().catch(() => {}))
+
+    await page.getByRole('button', { name: /PDF出力/ }).click()
+
+    // Main page toolbar should still be visible
+    await expect(page.getByTitle('線分')).toBeVisible()
+  })
+})

--- a/src/components/Canvas/CanvasArea.tsx
+++ b/src/components/Canvas/CanvasArea.tsx
@@ -27,6 +27,7 @@ export function CanvasArea() {
   const gridVisible = useCanvasStore((s) => s.gridVisible)
   const scale = useCanvasStore((s) => s.scale)
   const setPan = useCanvasStore((s) => s.setPan)
+  const registerExportFn = useCanvasStore((s) => s.registerExportFn)
 
   const layers = useLayerStore((s) => s.layers)
   const shapes = useLayerStore((s) => s.shapes)
@@ -70,6 +71,13 @@ export function CanvasArea() {
     ro.observe(el)
     return () => ro.disconnect()
   }, [])
+
+  // Register high-DPI export function so Toolbar can trigger canvas capture
+  useEffect(() => {
+    registerExportFn((pixelRatio = 3) => {
+      return stageRef.current?.toDataURL({ pixelRatio }) ?? ''
+    })
+  }, [registerExportFn])
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {

--- a/src/components/Toolbar/Toolbar.tsx
+++ b/src/components/Toolbar/Toolbar.tsx
@@ -16,6 +16,7 @@ export function Toolbar() {
     snapMidpoint, setSnapMidpoint,
     snapIntersection, setSnapIntersection,
     resetView,
+    exportFn,
   } = useCanvasStore()
   const { layers, shapes, selectedIds, clearDocument, loadDocument, transformSelectedShapes } = useLayerStore()
   const hasSelection = selectedIds.length > 0
@@ -55,6 +56,44 @@ export function Toolbar() {
 
   const handleDxfImport = () => dxfInputRef.current?.click()
 
+  const handlePrint = () => {
+    const dataUrl = exportFn ? exportFn(3) : ''
+    if (!dataUrl) { window.print(); return }
+    const win = window.open('', '_blank')
+    if (!win) { window.print(); return }
+
+    const style = win.document.createElement('style')
+    style.textContent = [
+      '* { margin: 0; padding: 0; box-sizing: border-box; }',
+      'body { background: #fff; font-family: sans-serif; }',
+      'img { width: 100%; height: auto; display: block; }',
+      '#ctrl { position: fixed; top: 8px; right: 8px; display: flex; gap: 8px; }',
+      '#ctrl button { padding: 4px 12px; cursor: pointer; }',
+      '@media print { #ctrl { display: none; } @page { margin: 0; } }',
+    ].join(' ')
+
+    const img = win.document.createElement('img')
+    img.src = dataUrl
+
+    const ctrl = win.document.createElement('div')
+    ctrl.id = 'ctrl'
+
+    const printBtn = win.document.createElement('button')
+    printBtn.textContent = '印刷'
+    printBtn.addEventListener('click', () => win.print())
+
+    const closeBtn = win.document.createElement('button')
+    closeBtn.textContent = '閉じる'
+    closeBtn.addEventListener('click', () => win.close())
+
+    ctrl.appendChild(printBtn)
+    ctrl.appendChild(closeBtn)
+
+    win.document.head.appendChild(style)
+    win.document.body.appendChild(img)
+    win.document.body.appendChild(ctrl)
+  }
+
   const handleDxfFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (!file) return
@@ -85,7 +124,7 @@ export function Toolbar() {
       <button onClick={handleSave} className="px-2 py-1 bg-gray-600 hover:bg-gray-500 rounded">保存</button>
       <button onClick={handleDxfImport} className="px-2 py-1 bg-indigo-700 hover:bg-indigo-600 rounded">DXF読込</button>
       <button onClick={handleDxf} className="px-2 py-1 bg-blue-700 hover:bg-blue-600 rounded">DXF出力</button>
-      <button onClick={() => window.print()} className="px-2 py-1 bg-purple-700 hover:bg-purple-600 rounded">PDF出力</button>
+      <button onClick={handlePrint} className="px-2 py-1 bg-purple-700 hover:bg-purple-600 rounded">PDF出力</button>
       <input ref={fileInputRef} type="file" accept=".civil,.json" className="hidden" onChange={handleFileChange} />
       <input ref={dxfInputRef} type="file" accept=".dxf" className="hidden" onChange={handleDxfFileChange} />
 

--- a/src/store/canvasStore.ts
+++ b/src/store/canvasStore.ts
@@ -38,6 +38,7 @@ interface CanvasState {
   snapIntersection: boolean
   cursorX: number
   cursorY: number
+  exportFn: ((pixelRatio?: number) => string) | null
   setZoom: (zoom: number) => void
   setPan: (x: number, y: number) => void
   setScale: (scale: Scale) => void
@@ -50,6 +51,7 @@ interface CanvasState {
   setSnapIntersection: (v: boolean) => void
   setCursor: (x: number, y: number) => void
   resetView: () => void
+  registerExportFn: (fn: (pixelRatio?: number) => string) => void
 }
 
 export const useCanvasStore = create<CanvasState>()((set) => ({
@@ -66,6 +68,7 @@ export const useCanvasStore = create<CanvasState>()((set) => ({
   snapIntersection: true,
   cursorX: 0,
   cursorY: 0,
+  exportFn: null,
   setZoom: (zoom) => set({ zoom: Math.min(50, Math.max(0.1, zoom)) }),
   setPan: (panX, panY) => set({ panX, panY }),
   setScale: (scale) => set({ scale }),
@@ -78,4 +81,5 @@ export const useCanvasStore = create<CanvasState>()((set) => ({
   setSnapIntersection: (snapIntersection) => set({ snapIntersection }),
   setCursor: (cursorX, cursorY) => set({ cursorX, cursorY }),
   resetView: () => set({ zoom: 1, panX: 0, panY: 0 }),
+  registerExportFn: (fn) => set({ exportFn: fn }),
 }))


### PR DESCRIPTION
## 変更内容

PERF-003: 印刷時の高DPI出力対応

### 実装詳細

| ファイル | 変更内容 |
|---|---|
| `src/store/canvasStore.ts` | `exportFn` / `registerExportFn` をストアに追加（コールバック登録パターン） |
| `src/components/Canvas/CanvasArea.tsx` | Konva `Stage.toDataURL({ pixelRatio: 3 })` をマウント時に登録 |
| `src/components/Toolbar/Toolbar.tsx` | `handlePrint` — 別ウィンドウに高DPI canvas 画像を表示 |
| `e2e/print-hires.spec.ts` | PERF-003 E2E テスト 2 シナリオ |

### アーキテクチャのポイント

- Toolbar と CanvasArea が互いを知らないよう、Zustand ストアを関数レジストリとして活用
- `pixelRatio: 3` → 288dpi 相当（96dpi CSS ベース × 3倍）
- `document.write()` を避けた DOM 操作による印刷プレビューウィンドウ（セキュリティフック対応）
- ポップアップブロック時は `window.print()` にフォールバック

## テスト結果

- lint: ✅ ESLint エラーなし
- build: ✅ Vite ビルド成功
- E2E ローカル: SIGTRAP（環境レベルのヘッドレス Chromium クラッシュ — CI-002 と同一の既知問題）
- CI での E2E 検証待ち

## 影響範囲

- PDF出力ボタンの動作変更（`window.print()` → 印刷プレビューウィンドウ）
- 高DPI キャプチャにより印刷品質が大幅向上

## 残課題

- なし（AUTH-001 / DXF-002 は外部ブロッカー、本 PR と無関係）

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)